### PR TITLE
Ignore archived trips after preset date

### DIFF
--- a/src/routers/trip-router.js
+++ b/src/routers/trip-router.js
@@ -21,6 +21,13 @@ tripsRouter.route('/')
     }
     if (req.query.getPastTrips === 'false') {
       filters.startDateAndTime = { $gte: new Date() };
+    } else {
+      filters.startDateAndTime = {
+        $gte: new Date(
+          process.env.ARCHIVE_START_YEAR || '2020',
+          process.env.ARCHIVE_START_MONTH || '0'
+        ),
+      };
     }
     controllers.trips.getTrips(filters).then((result) => {
       res.json(result);


### PR DESCRIPTION
Use a env-set year + month criteria to archive trips. Ignore trips older than this archival mark date in the "get all trips" query. Manual trip search by ID will still ping archived trips.