### PR TITLE
allowing clubs to be empty and still show up in OPO view

### DIFF
--- a/src/routes/opo/vehicle-requests.js
+++ b/src/routes/opo/vehicle-requests.js
@@ -18,14 +18,17 @@ function getRequestedVehicles(req) {
         requested_vehicles.mileage,
         users.name as requester_name,
         trips.id as trip_id,
-        trips.title as reason,
+        trips.title as reason,  
+        trips.start_time,
+        clubs.name as club_requesting,
         iif(vehiclerequests.is_approved IS NULL, 'pending', iif(is_approved = 1, 'approved', 'denied')) as status
       FROM requested_vehicles
       JOIN vehiclerequests ON vehiclerequests.id = requested_vehicles.vehiclerequest
       JOIN trips ON trips.id = vehiclerequests.trip
       JOIN users on users.id =  trips.owner
+      JOIN clubs on clubs.id = trips.club
       WHERE pickup_time > ?
-      ORDER BY pickup_time `, now.getTime()
+      ORDER BY start_time `, now.getTime()
   )
 }
 

--- a/src/routes/opo/vehicle-requests.js
+++ b/src/routes/opo/vehicle-requests.js
@@ -20,13 +20,13 @@ function getRequestedVehicles(req) {
         trips.id as trip_id,
         trips.title as reason,  
         trips.start_time,
-        clubs.name as club_requesting,
+        coalesce(clubs.name, 'None') as club_requesting,
         iif(vehiclerequests.is_approved IS NULL, 'pending', iif(is_approved = 1, 'approved', 'denied')) as status
       FROM requested_vehicles
       JOIN vehiclerequests ON vehiclerequests.id = requested_vehicles.vehiclerequest
       JOIN trips ON trips.id = vehiclerequests.trip
       JOIN users on users.id =  trips.owner
-      JOIN clubs on clubs.id = trips.club
+      LEFT JOIN clubs on clubs.id = trips.club
       WHERE pickup_time > ?
       ORDER BY start_time `, now.getTime()
   )

--- a/src/templates/views/opo/vehicle-requests.njk
+++ b/src/templates/views/opo/vehicle-requests.njk
@@ -14,7 +14,7 @@
 {% else %}
 <div class=trip-table-overflow-wrapper>
 <table class=trip-table>
-<thead><tr><th>Trip #<th>Title <th> Mileage<th>Requester<th>Pickup<th>Return
+<thead><tr><th>Trip #<th>Title<th>Club<th>Mileage<th>Requester<th>Pickup<th>Return
 <tbody>
   {% set last_trip_id = null %}
   {% for request in pending_requests %}
@@ -24,6 +24,7 @@
       {% endif %}
       {% set last_trip_id = request.trip_id %}
   <td><a href="/leader/trip/{{request.trip_id}}#vehicle-request">{{request.reason}}</a>
+  <td>{{request.club_requesting}}
   <td>{{request.mileage}}
   <td>{{request.requester_name}}
   <td>{{request.pickup_time_element | safe }}


### PR DESCRIPTION
accidentally used "JOIN" instead of "LEFT JOIN" so trips that weren't part of a club wouldn't show up 

<img width="2452" height="174" alt="image" src="https://github.com/user-attachments/assets/a878830f-8560-4423-b3f7-4cf44a9e655d" />
