### PR TITLE
Adding a (boring) 404 page instead of the scary "not found" message 

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -34,7 +34,7 @@ export function startServer(trailheadDb, port) {
   app.get('/healthcheck', (_, res) => { res.send('OK') })
   app.use('/', apiRouter)
   app.all('*', (req, res, next) => {
-    next({ code: 404, message: 'Page not found' })
+    next({ code: 404 })
   })
   app.use(handleError)
 
@@ -45,7 +45,7 @@ export function startServer(trailheadDb, port) {
 }
 
 function handleError(err, req, res, _next) {
-  if (err.code == 404) {
+  if (err.code === 404) {
     res.status(err.code).render('errors/response404.njk')
   } else if (err.code < 500) {
     res.status(err.code).send(err.message)

--- a/src/server.js
+++ b/src/server.js
@@ -30,11 +30,16 @@ export function startServer(trailheadDb, port) {
     .addGlobal('FULLCALENDAR_VERSION', FULLCALENDAR_VERSION)
     .addGlobal('ORIGIN', constants.ORIGIN)
   app.set('views', 'templates/views')
-
   app.use((req, _res, next) => { req.db = trailheadDb; next() })
   app.get('/healthcheck', (_, res) => { res.send('OK') })
   app.use('/', apiRouter)
+  app.all('*', (req, res, next) => {
+    //TODO: clean this
+    //TODO: code vs status? (here, handleError, and in errors.js)
+    next({ code: 404, status: 404, message: 'Page not found' })
+  })
   app.use(handleError)
+
 
   const server = app.listen(port)
   console.log(`Server running at http://localhost:${server.address().port}`)
@@ -43,7 +48,12 @@ export function startServer(trailheadDb, port) {
 }
 
 function handleError(err, req, res, _next) {
-  if (err.code < 500) {
+  console.log("handling an error...")
+  if (err.code == 403) {
+    res.status(err.code).render('errors/response403.njk')
+  } else if (err.code == 404) {
+    res.status(err.code).render('errors/response404.njk')
+  } else if (err.code < 500) {
     res.status(err.code).send(err.message)
   } else {
     console.error(`Unexpected error for ${req.method} ${req.url}, sending 500`)

--- a/src/server.js
+++ b/src/server.js
@@ -34,12 +34,9 @@ export function startServer(trailheadDb, port) {
   app.get('/healthcheck', (_, res) => { res.send('OK') })
   app.use('/', apiRouter)
   app.all('*', (req, res, next) => {
-    //TODO: clean this
-    //TODO: code vs status? (here, handleError, and in errors.js)
-    next({ code: 404, status: 404, message: 'Page not found' })
+    next({ code: 404, message: 'Page not found' })
   })
   app.use(handleError)
-
 
   const server = app.listen(port)
   console.log(`Server running at http://localhost:${server.address().port}`)
@@ -48,10 +45,7 @@ export function startServer(trailheadDb, port) {
 }
 
 function handleError(err, req, res, _next) {
-  console.log("handling an error...")
-  if (err.code == 403) {
-    res.status(err.code).render('errors/response403.njk')
-  } else if (err.code == 404) {
+  if (err.code == 404) {
     res.status(err.code).render('errors/response404.njk')
   } else if (err.code < 500) {
     res.status(err.code).send(err.message)

--- a/src/templates/errors/response404.njk
+++ b/src/templates/errors/response404.njk
@@ -1,0 +1,10 @@
+{% include "common/site-head.njk" %}
+<title>Trip Not Found - DOC Trailhead</title>
+
+{% include "common/site-nav.njk" %}
+<main style="display: flex; flex-direction: column; align-items: center;">
+<h1>Site Not Found</h1>
+<p> Oops! Unfortunately that side could not be found.
+<p><a href="/all-trips">Click here</a> to find a trip!
+</main>
+


### PR DESCRIPTION
resolves #147 

pretty basic, I would like to also add a similar one for 403 responses in place of the ominous "forbidden" but it requires a little bit more. 

I don't know if its an issue, but I will acknowledge that the OPO-specific nav bar items ('admin' and 'calendar') do not appear here since I thought it would be counterintuitive to bake such logic into an error page. Obviously it wouldn't be hard to do so, so let me know if I'm wrong. 