### PR TITLE
Check in / Check out tweaks 

### DIFF
--- a/src/emails.js
+++ b/src/emails.js
@@ -2,7 +2,7 @@ import nunjucks from 'nunjucks'
 
 import * as constants from './constants.js'
 
-const _48_HOURS_IN_MS = 172800000
+const _24_HOURS_IN_MS = 86400000
 const _1_HOUR_IN_MS = 3600000
 const _2_HOURS_IN_MS = 7200000
 
@@ -206,7 +206,7 @@ export function getTripGearChangedNotice(db, tripId) {
 
 export function getEmailsForTripsPendingCheckOut(db) {
   const now = new Date()
-  const emailWindow = new Date(now.getTime() + _48_HOURS_IN_MS)
+  const emailWindow = new Date(now.getTime() + _24_HOURS_IN_MS)
   const trips = db.all(`
     SELECT *
     FROM trips

--- a/src/routes/trip/check-in.js
+++ b/src/routes/trip/check-in.js
@@ -8,8 +8,10 @@ export function get(req, res) {
       id as trip_id,
       title,
       left as checked_out,
-      returned as checked_in
+      returned as checked_in,
+      trip_pcard_requests.is_approved as pcard_approved
     FROM trips
+    LEFT JOIN trip_pcard_requests on trip_pcard_requests.trip = trip_id
     WHERE id = ?
   `, tripId)
   res.render('views/trip-check-in.njk', trip)

--- a/src/routes/trip/trip-card.js
+++ b/src/routes/trip/trip-card.js
@@ -2,7 +2,7 @@ import * as utils from '../../utils.js'
 import * as gear from './gear/gear.js'
 import { getVehicleRequestData } from '../vehicle-request.js'
 
-const _48_HOURS_IN_MS = 172800000
+const _24_HOURS_IN_MS = 86400000
 
 function getLeaderData(req, tripId, userId) {
   const user = req.db.get('SELECT is_opo FROM users WHERE id = ?', userId)
@@ -144,7 +144,7 @@ function getLeaderData(req, tripId, userId) {
 
   // Enable status buttons if we're close enough to trip-start
   const now = (new Date()).getTime()
-  if (trip.start_time < now + _48_HOURS_IN_MS) trip.check_out_enabled = true
+  if (trip.start_time < now + _24_HOURS_IN_MS) trip.check_out_enabled = true
   // Enable check-in if the trip has left; *disable* *check-out* if the trip has returned
   if (trip.left === 1) trip.check_in_enabled = true
   if (trip.returned === 1) trip.check_out_enabled = false

--- a/src/templates/emails/check-out.njk
+++ b/src/templates/emails/check-out.njk
@@ -1,6 +1,6 @@
 Hello,
 
-Your Trip #{{ trip.id }}: {{ trip.title }} is happening in 48 hours!
+Your Trip #{{ trip.id }}: {{ trip.title }} is happening in 24 hours!
 
 Please mark all attendees before you leave {{ trip.pickup }}: {{ constants.ORIGIN }}/trip/{{ trip.id }}/check-out
 

--- a/src/templates/trip/check-in-links.njk
+++ b/src/templates/trip/check-in-links.njk
@@ -1,0 +1,12 @@
+<p>
+If you had an incident or a near-miss on your trip,
+<a href="https://docs.google.com/forms/u/1/d/e/1FAIpQLSeo9jIcTGNstZ1uADtovDjJT8kkPtS-YpRwzJC2MZkVkbH0hw/viewform">
+  click here to file an incident report.</a>
+
+{% if pcard_approved == 1 %} 
+<p>
+Your trip has an approved pcard request associated with it. 
+<a href="https://docs.google.com/forms/d/e/1FAIpQLSeO7JDqULXJHDhtWAwvKFWqQN4McF3P71OOgCiWPp_wpuAGMg/viewform">
+  Please make sure to fill out the expense form. </a>
+{% endif %}
+

--- a/src/templates/trip/leader-trip-card.njk
+++ b/src/templates/trip/leader-trip-card.njk
@@ -21,7 +21,7 @@ You are currently viewing this trip as a leader.
 <section>
 <h2>Check-In and Check-Out</h2>
 <p>It is very important to alert the Outdoor Programs Office that your trip is leaving and returning
-on time. 48 hours before trip-start you can begin checking out your trip.
+on time. 24 hours before trip-start you can begin checking out your trip.
 <div class=button-row>
   <a class="action approve"
      {% if check_out_enabled %}href="/trip/{{trip_id}}/check-out"{% endif %}

--- a/src/templates/trip/leader-trip-card.njk
+++ b/src/templates/trip/leader-trip-card.njk
@@ -263,6 +263,7 @@ on time. 24 hours before trip-start you can begin checking out your trip.
       <input name=assigned_pcard
              type=text
              value="{{ pcard_request.assigned_pcard }}"
+             required
              {% if pcard_request.is_approved === 1 %}disabled{%endif%}
              >
     </label>

--- a/src/templates/views/trip-check-in.njk
+++ b/src/templates/views/trip-check-in.njk
@@ -1,6 +1,6 @@
 {% include "common/site-head.njk" %}
 <title>Trip Check-In - DOC Trailhead</title>
-<link rel="stylesheet" href="/static/css/trip.css?id=1">
+<link rel="stylesheet" href="/static/css/trip.css">
 
 {% include "common/site-nav.njk" %}
 
@@ -8,34 +8,28 @@
 <section class=info-card>
 <h1>Trip Check-In ({{ title }})</h1>
 <p><a href="/leader/trip/{{trip_id}}">Return to the trip overview page</a>
+
 {% if not checked_out %}
 <p>Your trip is not checked out, so there's no need to check it back in!
 <p><a href="/trip/{{trip_id}}/check-out">Go to the check-out page</a>
 <p><a href="/leader/trip/{{trip_id}}">Return to the trip overview page</a>
+
 {% elseif not checked_in %}
 <div><button class="action approve"
              hx-put="/trip/{{trip_id}}/check-in"
              hx-confirm="Are you sure you want to check in?"
              >We have returned safely
-</button></div>
-<p>
-If you had an incident or a near-miss on your trip,
-<a href="https://docs.google.com/forms/u/1/d/e/1FAIpQLSeo9jIcTGNstZ1uADtovDjJT8kkPtS-YpRwzJC2MZkVkbH0hw/viewform">
-  click here to file an incident report.</a>
+</button>
+</div>
+{% include "trip/check-in-links.njk" %}
+
 {% else %}
 <div><button class="action deny"
              hx-delete="/trip/{{trip_id}}/check-in"
              hx-confirm="Are you sure you want to undo your check in?"
              >Undo Check-In
 </button></div>
-<p>
-If you had an incident or a near-miss on your trip,
-<a href="https://docs.google.com/forms/u/1/d/e/1FAIpQLSeo9jIcTGNstZ1uADtovDjJT8kkPtS-YpRwzJC2MZkVkbH0hw/viewform"
-   target=_blank
-   >click here to file an incident report</a> (opens in a new tab).
+{% include "trip/check-in-links.njk" %}
 {% endif %}
-
 </section>
 </main>
-
-

--- a/src/templates/views/trip-check-in.njk
+++ b/src/templates/views/trip-check-in.njk
@@ -14,7 +14,7 @@
 <p><a href="/trip/{{trip_id}}/check-out">Go to the check-out page</a>
 <p><a href="/leader/trip/{{trip_id}}">Return to the trip overview page</a>
 
-{% elseif not checked_in %}
+{% elif not checked_in %}
 <div><button class="action approve"
              hx-put="/trip/{{trip_id}}/check-in"
              hx-confirm="Are you sure you want to check in?"


### PR DESCRIPTION
A couple small, specifically requested changes. Notably, the window to check out a trip is changed from 48 hours to 24 hours in advance (and the email accordingly). Likewise, OPO wanted to add their "fill out any P card expenses" form to the check in screen, which I've made show up conditionally only if the trip had an approved pcard request.

In the process, I split `src/templates/views/trip-check-in.njk` into two so as to not have the urls on more than one line. 

Likewise, while testing, I noticed that trailhead currently yells at you with an obnoxious error banner if OPO tries to click approve pcard without entering a number, so I simply made the input required in `src/templates/trip/leader-trip-card.njk ` 

(this _might_ be my last PR of the night but who knows)
