### PR TITLE
Logic for showing attended students was flipped 

### DIFF
--- a/src/routes/trip/trip-card.js
+++ b/src/routes/trip/trip-card.js
@@ -53,7 +53,7 @@ function getLeaderData(req, tripId, userId) {
     leader,
     pending,
     created_at,
-    iif(trips.start_time < unixepoch() * 1000,
+    iif(trips.start_time < unixepoch(),
         '-',
         iif(attended = 0, 'No', 'Yes')) as attended,
     allergies_dietary_restrictions,

--- a/src/routes/trip/trip-card.js
+++ b/src/routes/trip/trip-card.js
@@ -53,9 +53,11 @@ function getLeaderData(req, tripId, userId) {
     leader,
     pending,
     created_at,
-    iif(trips.start_time > unixepoch() * 1000,
-        '-',
-        iif(attended = 0, 'No', 'Yes')) as attended,
+    CASE 
+      WHEN trips.start_time > unixepoch() * 1000 THEN '-'
+      WHEN attended = 0 THEN 'No'
+      WHEN attended = 1 THEN 'Yes' 
+    END as attended,
     allergies_dietary_restrictions,
     medical_conditions,
     iif(users.id = trips.owner, 1, 0) as is_owner

--- a/src/routes/trip/trip-card.js
+++ b/src/routes/trip/trip-card.js
@@ -53,7 +53,7 @@ function getLeaderData(req, tripId, userId) {
     leader,
     pending,
     created_at,
-    iif(trips.start_time < unixepoch(),
+    iif(trips.start_time > unixepoch() * 1000,
         '-',
         iif(attended = 0, 'No', 'Yes')) as attended,
     allergies_dietary_restrictions,


### PR DESCRIPTION
@alexpetros this one is at least _moderately_ timely (but still far from truly urgent). 

I got an email asking me to check whether or not a given student was marked as present for a specific trip...which should be possible for OPO to see. I may be mistaken, but it seems like the inequality `trips.start_time < unixepoch()` was just flipped? 

Previously it showed '-' for all students in all trips BEFORE unixepoch and 'no' for all students in all future trips. While I was at it, I quickly rewrote the nested iifs into a case statement to make it slightly more approachable. 

